### PR TITLE
replace non-standard malloc.h with standard stdlib.h

### DIFF
--- a/client.c
+++ b/client.c
@@ -4,7 +4,7 @@
  *  \brief microhttpd client Implementation 
  */
 #include <unistd.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <string.h>
 #include "debug.h"
 #include "helpers.h"

--- a/helpers.c
+++ b/helpers.c
@@ -4,7 +4,7 @@
  *  \brief microhttpd helpers
  */
 #include <unistd.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
 #include "debug.h"

--- a/microhttpd.c
+++ b/microhttpd.c
@@ -4,7 +4,6 @@
  *  \brief microhttpd Implementation 
  */
 #include <unistd.h>
-#include <malloc.h>
 #include <string.h>
 #include <fcntl.h>
 #include <stdlib.h>


### PR DESCRIPTION
Hello, thank you for this library, it works great for me. Only thing I ran into is that my clang compiler doesn't like the use of `malloc.h` as it seems to be a somewhat Linux specific thing. 